### PR TITLE
Update the `debug` dependency

### DIFF
--- a/slm.toml
+++ b/slm.toml
@@ -1,5 +1,5 @@
 name = "microchip-networking"
-version = "0.6.0"
+version = "0.6.1"
 [dependencies]
 passives = { git = "JITx-Inc/passives", version = "0.1.0" }
 power-systems = { git = "JITx-Inc/power-systems", version = "0.5.0" }

--- a/slm.toml
+++ b/slm.toml
@@ -3,4 +3,5 @@ version = "0.6.0"
 [dependencies]
 passives = { git = "JITx-Inc/passives", version = "0.1.0" }
 power-systems = { git = "JITx-Inc/power-systems", version = "0.5.0" }
-debug = { git = "JITx-Inc/debug", version = "0.3.2" }
+debug = { git = "JITx-Inc/debug", 
+version = "0.3.3" }


### PR DESCRIPTION
Was referencing an older version that specified a JSL version. This was causing issues with latest release of JITX.